### PR TITLE
Return nodeName instead of anchorName  on android like is done on iOS.

### DIFF
--- a/android/src/main/kotlin/com/uhg0/ar_flutter_plugin_2/ArView.kt
+++ b/android/src/main/kotlin/com/uhg0/ar_flutter_plugin_2/ArView.kt
@@ -500,6 +500,7 @@ class ArView(
                         if (node != null) {
                             var anchorName: String? = null
                             var currentNode: Node? = node
+                            val nodeName = node.name
                             while (currentNode != null) {
                                 anchorNodesMap.forEach { (name, anchorNode) ->
                                     if (currentNode == anchorNode) {
@@ -511,7 +512,7 @@ class ArView(
                                 currentNode = currentNode.parent
                             }
                             if(handleTaps) {
-                                objectChannel.invokeMethod("onNodeTap", listOf(anchorName))
+                                objectChannel.invokeMethod("onNodeTap", listOf(nodeName))
                             }
                             true
                         } else {


### PR DESCRIPTION
Return nodeName instead of anchorName  on android like is done on iOS. Closes #12 