### PR TITLE
Fix local file model loading (fileSystemAppFolderGLB/GLTF2)

### DIFF
--- a/android/src/main/kotlin/com/uhg0/ar_flutter_plugin_2/ArView.kt
+++ b/android/src/main/kotlin/com/uhg0/ar_flutter_plugin_2/ArView.kt
@@ -201,11 +201,18 @@ class ArView(
                     fileLocation = fileLocation
                 }
                 2 -> { // fileSystemAppFolderGLB
-                    fileLocation = fileLocation
+                    // Resolve against the Flutter app documents directory
+                    // (dataDir/app_flutter), where callers place local models.
+                    // Previously this branch was a no-op, so the bare filename
+                    // reached the loader and threw FileNotFoundException.
+                    val documentsPath = viewContext.getApplicationInfo().dataDir
+                    fileLocation = documentsPath + "/app_flutter/" + (nodeData["uri"] as String)
                 }
                  3 -> { //fileSystemAppFolderGLTF2
+                    // Previously assigned to a shadowing local val, so the
+                    // computed path was discarded.
                     val documentsPath = viewContext.getApplicationInfo().dataDir
-                    val fileLocation = documentsPath + "/app_flutter/" + nodeData["uri"] as String
+                    fileLocation = documentsPath + "/app_flutter/" + (nodeData["uri"] as String)
                  }
                 else -> {
                     return null
@@ -221,7 +228,19 @@ class ArView(
         }
 
         return try {
-            sceneView.modelLoader.loadModelInstance(fileLocation)?.let { modelInstance ->
+            // sceneview's string loader resolves non-http locations through
+            // AssetManager, which cannot open absolute filesystem paths -
+            // read those files directly and hand Filament the raw buffer.
+            val loadedInstance = if (fileLocation.startsWith("/")) {
+                val bytes = java.io.File(fileLocation).readBytes()
+                val buffer = java.nio.ByteBuffer.allocateDirect(bytes.size)
+                buffer.put(bytes)
+                buffer.rewind()
+                sceneView.modelLoader.createModelInstance(buffer)
+            } else {
+                sceneView.modelLoader.loadModelInstance(fileLocation)
+            }
+            loadedInstance?.let { modelInstance ->
                 object : ModelNode(
                     modelInstance = modelInstance,
                     scaleToUnits = transformation.first().toFloat(),


### PR DESCRIPTION
`NodeType.fileSystemAppFolderGLB` currently cannot load any model — three bugs stack up in `buildModelNode`:

1. **The GLB branch is a no-op** (`fileLocation = fileLocation`), so the bare filename reaches the model loader and every placement throws `java.io.FileNotFoundException`.
2. **The GLTF2 branch discards its work**: it computes the correct `dataDir/app_flutter/` path but assigns it to a shadowing local `val`, so the outer variable keeps the bare filename.
3. **Even a correct absolute path can't load**: sceneview's string loader resolves non-http locations through `AssetManager` (`nativeOpenAsset` in the stack trace), which can't open filesystem paths.

This PR resolves both branches against the Flutter documents directory and, for absolute paths, reads the bytes directly and hands Filament a `ByteBuffer` via `modelLoader.createModelInstance`.

Verified on device (Galaxy S25+, ARCore): before — `FileNotFoundException` on every tap-to-place; after — local `.glb` models place and render correctly.

Found and fixed in production while building [VEEOP](https://veeop.com), an AR social location platform ([github.com/VEEOP-app](https://github.com/VEEOP-app)).