### PR TITLE
Fix race that dropped every successful cloud anchor upload callback

### DIFF
--- a/lib/managers/ar_anchor_manager.dart
+++ b/lib/managers/ar_anchor_manager.dart
@@ -98,12 +98,21 @@ class ARAnchorManager {
 
   /// Upload given anchor from the underlying AR scene to the Google Cloud Anchor API
   Future<bool?> uploadAnchor(ARAnchor anchor) async {
+    // Register the anchor as pending BEFORE the platform call: the native
+    // side fires onCloudAnchorUploaded before resolving this method call,
+    // so adding afterwards meant the callback always found an empty
+    // pendingAnchors list and threw "Bad state: No element" - the upload
+    // succeeded but onAnchorUploaded never fired.
     try {
+      pendingAnchors.add(anchor);
       final response =
           await _channel.invokeMethod<bool>('uploadAnchor', anchor.toJson());
-      pendingAnchors.add(anchor);
+      if (response != true) {
+        pendingAnchors.remove(anchor);
+      }
       return response;
-    } on PlatformException catch (e) {
+    } on PlatformException {
+      pendingAnchors.remove(anchor);
       return false;
     }
   }


### PR DESCRIPTION
`ARAnchorManager.uploadAnchor` adds the anchor to `pendingAnchors` only **after** awaiting the platform call:

```dart
final response = await _channel.invokeMethod<bool>('uploadAnchor', anchor.toJson());
pendingAnchors.add(anchor);
```

But the native side invokes `onCloudAnchorUploaded` **before** resolving that method call (the Kotlin handler fires the callback and then calls `result.success`). So when the success callback runs, `pendingAnchors.where((e) => e.name == name).first` always throws `Bad state: No element` — the anchor hosts successfully in the cloud (log shows `UPLOADED ANCHOR WITH ID: ua-…`), but `onAnchorUploaded` never fires and the caller never receives the cloud anchor ID.

This PR registers the anchor as pending before the platform call and removes it again on failure, so the callback finds it and the API works as documented.

Verified on device: before — every successful host logged `Error caught: Bad state: No element`; after — `onAnchorUploaded` fires with the populated `cloudanchorid`.

Found and fixed in production while building [VEEOP](https://veeop.com), an AR social location platform ([github.com/VEEOP-app](https://github.com/VEEOP-app)).